### PR TITLE
Add 'reset discussion' feature

### DIFF
--- a/frontend/src/Lists/AdminFooter.js
+++ b/frontend/src/Lists/AdminFooter.js
@@ -5,11 +5,16 @@ import { ToolBarButton } from "../SharedComponents.js";
 
 class AdminFooter extends Component {
 	render() {
-		const { className, onClick, inactive } = this.props;
+		const { className, resetList, deleteList, inactive } = this.props;
 		return (
-			<Footer className={className} onClick={onClick} inactive={inactive}>
-				End discussion <FontAwesome name="trash" />
-			</Footer>
+			<div>
+				<Footer className={className} onClick={resetList} inactive={inactive}>
+					Reset discussion <FontAwesome name="retweet" />
+				</Footer>
+				<Footer className={className} onClick={deleteList} inactive={inactive}>
+					End discussion <FontAwesome name="trash" />
+				</Footer>
+			</div>
 		);
 	}
 }

--- a/frontend/src/Lists/List.js
+++ b/frontend/src/Lists/List.js
@@ -22,7 +22,8 @@ import {
 	requestDeleteList,
 	requestPopList,
 	requestSetDiscussionStatus,
-	requestListAdminAddUser, requestCreateList
+	requestListAdminAddUser,
+	requestCreateList
 } from "../actions.js";
 import RemoveUserButton from "./RemoveUserButton.js";
 

--- a/frontend/src/Lists/List.js
+++ b/frontend/src/Lists/List.js
@@ -22,7 +22,7 @@ import {
 	requestDeleteList,
 	requestPopList,
 	requestSetDiscussionStatus,
-	requestListAdminAddUser
+	requestListAdminAddUser, requestCreateList
 } from "../actions.js";
 import RemoveUserButton from "./RemoveUserButton.js";
 
@@ -77,6 +77,16 @@ class List extends Component {
 		const { list: { id } } = this.props;
 		store.dispatch(requestDeleteList(id));
 	};
+
+	resetList = () => {
+		if (this.props.inactive) {
+			return;
+		}
+
+		const { list: { title } } = this.props;
+		this.deleteList();
+		store.dispatch(requestCreateList(title))
+	}
 
 	nextSpeaker = () => {
 		if (this.props.inactive) {
@@ -160,7 +170,7 @@ class List extends Component {
 	};
 
 	renderAdminFooter = (listId, inactive) => {
-		return <AdminFooter onClick={this.deleteList} inactive={inactive} />;
+		return <AdminFooter deleteList={this.deleteList} resetList={this.resetList} inactive={inactive} />;
 	};
 
 	render() {


### PR DESCRIPTION
Solves #53, adds a "reset discussion" button which recreates a list by deleting it and creating a new one with the same name.
![example](https://user-images.githubusercontent.com/16452604/118379456-cbb3fa80-b5da-11eb-92e6-2a59e5e6456e.png)
